### PR TITLE
fix(hs-test-modules): Changed back to "main" function in each test module

### DIFF
--- a/haskell/Tests/AssemblyTest.hs
+++ b/haskell/Tests/AssemblyTest.hs
@@ -7,8 +7,8 @@ check :: String -> Bool -> String
 check name True = "PASS: " ++ name
 check name False = "FAIL: " ++ name 
 
-testAssembly :: IO()
-testAssembly = mapM_ putStrLn results
+main :: IO()
+main = mapM_ putStrLn results
 
 results :: [String]
 results = 

--- a/haskell/Tests/InstructionTest.hs
+++ b/haskell/Tests/InstructionTest.hs
@@ -37,8 +37,8 @@ unaryIns = createInstruction (destToken, negOpToken, varTokenA)
 assignIns :: Instruction
 assignIns = createInstruction (destToken, litToken)
 
-testLiveness :: IO ()
-testLiveness = mapM_ putStrLn results
+main :: IO ()
+main = mapM_ putStrLn results
 
 results :: [String]
 results =

--- a/haskell/Tests/InterferenceGraphTest.hs
+++ b/haskell/Tests/InterferenceGraphTest.hs
@@ -34,8 +34,8 @@ singleLiveLine = [[L.Live "a", L.Live "b"]]
 mixedLiveLine :: [LivenessStates]
 mixedLiveLine = [[L.Live "a", L.Unlive "b"]]
 
-testInterferenceGraph :: IO ()
-testInterferenceGraph = mapM_ putStrLn results
+main :: IO ()
+main = mapM_ putStrLn results
 
 results :: [String]
 results =

--- a/haskell/Tests/LivenessTest.hs
+++ b/haskell/Tests/LivenessTest.hs
@@ -46,8 +46,8 @@ assignYX = createInstruction (destY, createToken "x" Variable)
 binaryXAB :: Instruction
 binaryXAB = createInstruction (destX, varA, addOp, varB)
 
-testLiveness :: IO ()
-testLiveness = mapM_ putStrLn results
+main :: IO ()
+main = mapM_ putStrLn results
 
 results :: [String]
 results =

--- a/haskell/Tests/TokenTest.hs
+++ b/haskell/Tests/TokenTest.hs
@@ -6,8 +6,8 @@ check :: String -> Bool -> String
 check name True = "PASS: " ++ name
 check name False = "FAIL: " ++ name 
 
-testToken :: IO ()
-testToken = mapM_ putStrLn results
+main :: IO ()
+main = mapM_ putStrLn results
 
 results :: [String]
 results = 

--- a/haskell/makefile
+++ b/haskell/makefile
@@ -27,6 +27,9 @@ test-assembly:
 test-all:
 	runghc Tests/TokenTest.hs
 	runghc Tests/InstructionTest.hs
+	runghc Tests/LivenessTest.hs
+	runghc Tests/InterferenceGraphTest.hs
+	runghc Tests/AssemblyTest.hs
 
 clean:
 	rm -rf $(OUT)


### PR DESCRIPTION
I forgot the `makefile` had a `test-all` rule that automatically compiled and ran every test module when called. 
I originally changed each module to have a `test<ModuleName>` entry function rather than a `main` function and this actually broke the `test-all` rule without me realizing.
So the entry functions have been renamed to `main`. 
I also added all current Haskell test modules to the `test-all` rule. 