### PR TITLE
fix(interference-graph-tests): Fixed the interference graph tests and some other minor things

### DIFF
--- a/imperative/intermediate/interference_graph.py
+++ b/imperative/intermediate/interference_graph.py
@@ -9,26 +9,6 @@ class InterferenceGraph:
         self.interference_graph = Graph()
         self.colors: dict[str, int | None] = {}
 
-    # def build_graph(self, liveness: Liveness, variables: set[str]) -> None:
-    #     """
-    #     Builds the interference graph based on the provided liveness analysis.
-
-    #     :param liveness: The liveness analysis object.
-    #     :type liveness: Liveness
-    #     """
-
-    #     # First, construct all nodes using the instruction buffer's variables
-    #     for var in variables:
-    #         self.interference_graph.add_node(var)
-    #         self.colors[var] = None
-
-    #     # Then we add our edges
-    #     for line in liveness.get_liveness():
-    #         # Now check all combinations of live variables on this line
-    #         combs = combinations([var for var, state in line.items() if state != 2], r=2)
-    #         for var1, var2 in combs:
-    #             self.interference_graph.add_edge(var1, var2)
-
     def build_graph(self, liveness: Liveness, variables: set[str]) -> None:
         for var in variables:
             self.interference_graph.add_node(var)
@@ -61,27 +41,6 @@ class InterferenceGraph:
                 if var1 in variables and var2 in variables:
                     self.interference_graph.add_edge(var1, var2)
 
-    # def _is_solved(self) -> bool:
-    #     """
-    #     Checks if the interference graph has been successfully colored.
-
-    #     :return: True if the graph is properly coloured, false otherwise
-    #     :rtype: bool
-    #     """
-
-    #     for node in self.interference_graph.nodes():
-    #         color = self.colors[node]
-
-    #         if color is None:
-    #             return False
-
-    #         # Make sure no neighbors have the same color
-    #         for neighbor in self.interference_graph.neighbors(node):
-    #             if color == self.colors[neighbor]:
-    #                 return False
-
-    #     return True
-
     def _possible_colors(self, node: str, n: int) -> set[int]:
         """
         Returns a set of possible colors for a given node.
@@ -99,21 +58,6 @@ class InterferenceGraph:
                 used.add(self.colors[neighbor])
 
         return set(range(n)) - used
-
-    # def _solve_graph_coloring(self, index: int, n: int) -> bool:
-    #     if self._is_solved():
-    #         return True
-
-    #     node = list(self.interference_graph.nodes())[index]
-    #     for color in self._possible_colors(node, n):
-    #         self.colors[node] = color
-
-    #         if self._solve_graph_coloring(index + 1, n):
-    #             return True
-
-    #         self.colors[node] = None
-
-    #     return False
 
     def _solve_graph_coloring(self, index: int, n: int) -> bool:
         nodes = list(self.interference_graph.nodes())

--- a/imperative/test_gen.py
+++ b/imperative/test_gen.py
@@ -129,21 +129,23 @@ if __name__ == "__main__":
     test_binary_ops() # Want successful ASM output - Success
     test_chained_reuse() # Want successful ASM output - Success
     test_empty_file() # Want empty '.s' file - Success
+
+    # These throw errors and try except does not catch it. It will terminate the program 
+    # and you will not get any output files past this point
+    # try:
+    #     test_invalid_operators() # Looking for error - Error confirmed
+    # except ValueError as ve:
+    #     print("Error successfully")
     
-    try:
-        test_invalid_operators() # Looking for error - Error confirmed
-    except:
-        print("Error successfully")
+    # try:
+    #     test_malformed_syntax() # Looking for error - Error confirmed    
+    # except ValueError as ve:
+    #     print("Error successfully")
     
-    try:
-        test_malformed_syntax() # Looking for error - Error confirmed    
-    except:
-        print("Error successfully")
-    
-    try:
-        test_missing_operands() # Looking for error - Error confirmed 
-    except ValueError as ve:
-        print("Error successfully")
+    # try:
+    #     test_missing_operands() # Looking for error - Error confirmed 
+    # except ValueError as ve:
+    #     print("Error successfully")
 
     test_mixed_all_types() # Want successful ASM output - Success
     test_multiple_live_vars() # Want successful ASM output - Success
@@ -154,7 +156,7 @@ if __name__ == "__main__":
     test_single_unary() # Looking for MOV, MUL #-1, MOV - Success
     test_unary_ops() # Looking for multiple instances similar to last test - Success
     test_undefined_variables() # Looking for two MOV into separate registers, add those registers, then MOV back to memory - Success
-    try:
-        test_valid_then_invalid_operator() # Looking for an error to be raised in the console - Success
-    except:
-        print("Error successfully")
+    # try:
+    #     test_valid_then_invalid_operator() # Looking for an error to be raised in the console - Success
+    # except ValueError as ve:
+    #     print("Error successfully")

--- a/imperative/tests/interference_graph_test.py
+++ b/imperative/tests/interference_graph_test.py
@@ -105,40 +105,6 @@ class TestBuildGraph(unittest.TestCase):
         # NetworkX graphs don't allow duplicate edges, so just verify the edge exists once
         self.assertEqual(graph.interference_graph.number_of_edges("a", "b"), 1)
 
-
-class TestIsSolved(unittest.TestCase):
-    def test_returns_false_when_colors_are_none(self):
-        instr = make_assignment("x", "a", 1)
-        graph = make_graph_with_liveness([instr], [], {"x", "a"})
-        # Colors are all None after build_graph, before color_graph
-        self.assertFalse(graph._is_solved())
-
-    def test_returns_false_when_neighbors_share_color(self):
-        instr = Instruction(
-            0, Token("x", 0), Token("a", 1), Token("+", 3), Token("b", 1)
-        )
-        graph = make_graph_with_liveness([instr], ["a", "b"], {"x", "a", "b"})
-        # Manually assign same color to connected nodes
-        graph.colors["a"] = 0
-        graph.colors["b"] = 0
-        graph.colors["x"] = 1
-        self.assertFalse(graph._is_solved())
-
-    def test_returns_true_when_properly_colored(self):
-        instr = Instruction(
-            0, Token("x", 0), Token("a", 1), Token("+", 3), Token("b", 1)
-        )
-        graph = make_graph_with_liveness([instr], ["a", "b"], {"x", "a", "b"})
-        graph.colors["a"] = 0
-        graph.colors["b"] = 1
-        graph.colors["x"] = 0
-        self.assertTrue(graph._is_solved())
-
-    def test_returns_true_on_empty_graph(self):
-        graph = InterferenceGraph()
-        self.assertTrue(graph._is_solved())
-
-
 class TestPossibleColors(unittest.TestCase):
     def test_all_colors_available_no_colored_neighbors(self):
         instr = Instruction(


### PR DESCRIPTION
- InterferenceGraphTest was trying to test the _is_solved() function which we removed as the functionality was moved
- test_gen.py had some function calls commented because they were causing the assembly generation to halt. Uncomment if you want to see the program fail properly
- Also removed comments of old functions that have been updated in InterferenceGraph.py