### PR TITLE
fix:(test-plans): Removed redundant test from test plan + some more

### DIFF
--- a/imperative/intermediate/interference_graph.py
+++ b/imperative/intermediate/interference_graph.py
@@ -10,6 +10,16 @@ class InterferenceGraph:
         self.colors: dict[str, int | None] = {}
 
     def build_graph(self, liveness: Liveness, variables: set[str]) -> None:
+        """
+        Builds interference graph based on liveness and instruction operands.
+        Adds a node for every variable, then for every variable conflicting
+        with another (i.e. live at the same time or appearing in the same
+        instructions), an edge is added.
+        
+        :param liveness: The liveness object containing line-by-line 
+        variable liveness states.
+        :param variables: All variables occurring in the program.
+        """
         for var in variables:
             self.interference_graph.add_node(var)
             self.colors[var] = None

--- a/imperative/tests/test-plans/InterferenceGraph-Test-Plan.md
+++ b/imperative/tests/test-plans/InterferenceGraph-Test-Plan.md
@@ -10,10 +10,6 @@
 | `build_graph()` — no edge for defined variable | Liveness line: `{"a": 0, "b": 1}` | No edge between `"a"` and `"b"` (`a` is defined, state == 2) | Passed — `has_edge("x", "a")` is `False` |
 | `build_graph()` — no self-edges | Any liveness with a single live variable | No self-edges in graph | Passed — `has_edge(node, node)` is `False` for all nodes |
 | `build_graph()` — no duplicate edges | Same pair of live vars appearing on multiple lines | Only one edge between the pair | Passed — `number_of_edges("a", "b") == 1` |
-| `_is_solved()` — returns False when colors are None | Graph with uncolored nodes | Returns `False` | Passed — returns `False` |
-| `_is_solved()` — returns False when neighbors share color | Two connected nodes with same color | Returns `False` | Passed — returns `False` |
-| `_is_solved()` — returns True when properly colored | All nodes colored, no neighbors share color | Returns `True` | Passed — returns `True` |
-| `_is_solved()` — returns True on empty graph | `InterferenceGraph()` with no nodes | Returns `True` | Passed — returns `True` |
 | `_possible_colors()` — all colors available | Node with no colored neighbors, `n = 3` | Returns `{0, 1, 2}` | Passed — returns `{0, 1, 2}` |
 | `_possible_colors()` — excludes neighbor colors | Node with two colored neighbors (`a=0`, `b=1`), `n = 3` | Returns `{2}` | Passed — returns `{2}` |
 | `_possible_colors()` — no colors available | Node whose neighbors use all `n` colors | Returns `set()` | Passed — returns `set()` |


### PR DESCRIPTION
Beyond removing redundant test plan I also added a comment for the `build_graph()` function in InterferenceGraph since it was omitted after redoing it.